### PR TITLE
fix: 서버 컴포넌트 react error boundary 이슈 해결

### DIFF
--- a/app/admin/write/rewrite/[postId]/page.tsx
+++ b/app/admin/write/rewrite/[postId]/page.tsx
@@ -1,4 +1,5 @@
 import { getPost } from "../../../utils";
+import { redirect } from "next/navigation";
 import WriteBoard from "../../../components/clientside/writeBoard";
 
 export default async function Rewrite({
@@ -7,7 +8,16 @@ export default async function Rewrite({
   params: { postId: string };
 }) {
   const { postId } = params;
-  const { post } = await getPost(postId);
+  const resData = await getPost(postId).then(res => {
+    if (!res) {
+      console.log("404 : post not found");
+      alert("404 : post not found");
+      redirect("/admin");
+    }
+    return res;
+  });
+
+  const { post } = resData;
 
   return <WriteBoard postData={post} type="REWRITE" />;
 }

--- a/app/posts/[postId]/error.tsx
+++ b/app/posts/[postId]/error.tsx
@@ -16,7 +16,8 @@ export default function Error({
 
   return (
     <>
-      {error.message === "post not found" ? (
+      {error.digest === "NEXT_NOT_FOUND" ||
+      error.message === "NEXT_NOT_FOUND" ? (
         <NotFound />
       ) : (
         <section>

--- a/app/posts/[postId]/page.tsx
+++ b/app/posts/[postId]/page.tsx
@@ -4,6 +4,7 @@ import SeriesBoard from "app/components/clientside/seriesBoard";
 import styles from "./styles/page.module.scss";
 import Image from "next/image";
 import generateRssFeed from "app/generateRSS";
+import { notFound } from "next/navigation";
 import { CommentBox } from "./components/clientside";
 import { getPost, mdParser } from "./utils";
 import { CardLayout } from "app/components/card";
@@ -15,7 +16,11 @@ export default async function Posts({
   params: { postId: string };
 }) {
   const { postId } = params;
-  const { post, recent, bothSidePosts } = await getPost(postId);
+  const resData = await getPost(postId).then(res => {
+    return res ? res : notFound();
+  });
+
+  const { post, recent, bothSidePosts } = resData;
   const recentPosts = recent
     .filter((post: any) => post.postId != postId)
     .slice(-3);
@@ -89,7 +94,11 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const URL = process.env.DEV_URL as string;
   const { postId } = params;
-  const { post } = await getPost(postId);
+  const resData = await getPost(postId).then(res => {
+    return res ? res : notFound();
+  });
+
+  const { post } = resData;
 
   return {
     title: post.title,

--- a/app/posts/[postId]/utils/getPost.ts
+++ b/app/posts/[postId]/utils/getPost.ts
@@ -5,12 +5,14 @@ export default cache(async function getPost(postId: string) {
   const postid = postId;
 
   try {
-    const res = await fetch(`${URL}/api/posts/${postid}`, {
+    const res = await fetch(`${URL || ""}/api/posts/${postid}`, {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     });
 
-    if (!res.ok) {
+    if (res.status === 404) {
+      return undefined;
+    } else if (!res.ok) {
       const failed = await res.json();
       throw new Error(failed.error as string);
     }


### PR DESCRIPTION
## 버그픽스
- react에서 서버 사이드에서 발생한 에러는 컴포넌트에서 캐치되지 않고 vercel 서버에서 처리됨 => 404 커스텀 에러 페이지로 안내되지 않음
- getPost에서 404 반환시 undefined 반환 후 page에서 next.js notFound()로 404만 따로 핸들링

참고자료 : https://ko.legacy.reactjs.org/docs/error-boundaries.html
